### PR TITLE
CI-1581: Reinstate (some) document type checks

### DIFF
--- a/wagtail_wordpress_import/block_builder_defaults.py
+++ b/wagtail_wordpress_import/block_builder_defaults.py
@@ -176,24 +176,34 @@ def document_linker(html):
 
 
 def get_or_save_document(href):
-    document_file_name = get_document_file_name(href)
-    existing_document = document_exists(document_file_name)
-    if not existing_document:
-        response, valid, type = fetch_url(href)
-        if valid:
-            temp_document = NamedTemporaryFile(delete=True)
-            temp_document.name = document_file_name
-            temp_document.write(response.content)
-            temp_document.flush()
-            retrieved_document = ImportedDocument(
-                file=File(file=temp_document), title=document_file_name
-            )
-            retrieved_document.save()
-            temp_document.close()
-            return retrieved_document
-        else:
-            print(f"RECEIVED INVALID DOCUMENT RESPONSE: {href}")
-    return existing_document
+    file_type = href.split(".")[-1]
+    if file_type in getattr(
+        settings,
+        "",
+        [
+            "pdf",
+            "ppt",
+            "docx",
+        ],
+    ):
+        document_file_name = get_document_file_name(href)
+        existing_document = document_exists(document_file_name)
+        if not existing_document:
+            response, valid, type = fetch_url(href)
+            if valid:
+                temp_document = NamedTemporaryFile(delete=True)
+                temp_document.name = document_file_name
+                temp_document.write(response.content)
+                temp_document.flush()
+                retrieved_document = ImportedDocument(
+                    file=File(file=temp_document), title=document_file_name
+                )
+                retrieved_document.save()
+                temp_document.close()
+                return retrieved_document
+            else:
+                print(f"RECEIVED INVALID DOCUMENT RESPONSE: {href}")
+        return existing_document
 
 
 # STREAMFIELD BLOCKS

--- a/wagtail_wordpress_import/block_builder_defaults.py
+++ b/wagtail_wordpress_import/block_builder_defaults.py
@@ -183,7 +183,21 @@ def get_or_save_document(href):
         [
             "pdf",
             "ppt",
+            "pptx",
+            "doc",
             "docx",
+            "xls",
+            "xlsm",
+            "xlsx",
+            "csv",
+            "txt",
+            "rtf",
+            "odt",  # Open Office format for word processing (text) documents
+            "fodt",  # Open Office format for word processing (text) documents
+            "ods",  # Open Office format for spreadsheets
+            "fods",  # Open Office format for spreadsheets
+            "odp",  # Open Office format for presentations
+            "fodp", # Open Office format for presentations
         ],
     ):
         document_file_name = get_document_file_name(href)


### PR DESCRIPTION
# Reinstate (some) document type checks

Partially reverts 7c059e5.
This is based on output during an import - some document checks (otherwise the importer attempts to add linked HTML pages as documents in their own right).

Ticket URL:
https://technologyprogramme.atlassian.net/browse/CI-1581
---

Testing

- [ ] CI passes
- [ ] If necessary, tests are added for new or fixed behaviour
- [ ] These changes do not reduce test coverage
- [x] No tests added as the expected lifespan for this package is limited

Documentation.

- [ ] This PR adds or updates documentation
- [x] Documentation changes are not necessary because: There is no existing reference to allowed document types in documentation
