### PR TITLE
CI-1581: Enclose title field with quotes

### DIFF
--- a/wagtail_wordpress_import/logger.py
+++ b/wagtail_wordpress_import/logger.py
@@ -18,7 +18,7 @@ class Logger:
         item = self.items[-1]
         if not item["id"] == 0:
             sys.stdout.write(
-                f"Wagtail ID: {item['id']}, {item['title']}, {item['result']}, {item['id']}, {item['wp_guid']}\n"
+                f"Wagtail ID: {item['id']}, \"{item['title']}\", {item['result']}, {item['id']}, {item['wp_guid']}\n"
             )
 
     def get_items_report_data(self):


### PR DESCRIPTION
# Enclose title field with quotes

The stdout is used as a CSV output for later analysis. Post titles often contain quotes, so need enclosing.

Ticket URL:
https://technologyprogramme.atlassian.net/browse/CI-1581
---

Testing

- [ ] CI passes
- [ ] If necessary, tests are added for new or fixed behaviour
- [x] These changes do not reduce test coverage

Documentation.

- [ ] This PR adds or updates documentation
- [x] Documentation changes are not necessary because: There is no existing reference to log output